### PR TITLE
Full exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ the corresponding command line usage is:
 
 Arguments specified with `*args` or `**kwargs` syntax are currently ignored; this may be improved in a future version.
 
+Quarg reserves long argument names beginning with `--quarg` for its own use; the corresponding parameter names should be avoided.
+
 Arguments with defaults are exposed as optional, named arguments, and
 the type of the command line argument is set to match that of the
 default value. In Python 3, type annotations are also used to set the
@@ -143,11 +145,13 @@ present). Boolean arguments are exposed as flags.
 If the command function runs to completion, the return value is
 printed to standard output (see `@quarg.output`, below), and the
 program exits with a status of 0 (success). If an exception is thrown,
-the string value of the exception (i.e., _without_ a stack trace) is
+the string value of the exception (i.e., _without_ a traceback) is
 printed to standard error, and the program exits with a status
 of 1. If there is an error parsing the command line arguments, the
 program immediately prints a usage message to standard error and exits
 with a status of 2.
+
+During development, it is often useful to output a traceback, as is the default behaviour for uncaught exceptions. This behaviour can be reinstated by passing the argument `--quarg-debug` on the command line, or setting the environment variable `QUARG_DEBUG`.
 
 Decorators are provided to allow more fine-grained (but entirely
 optional) control:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ of 1. If there is an error parsing the command line arguments, the
 program immediately prints a usage message to standard error and exits
 with a status of 2.
 
-During development, it is often useful to output a traceback, as is the default behaviour for uncaught exceptions. This behaviour can be reinstated by passing the argument `--quarg-debug` on the command line, or setting the environment variable `QUARG_DEBUG`.
+During development, it is often useful to output a traceback, as is the default behaviour for uncaught exceptions. This behaviour can be reinstated by passing the argument `--quarg-debug` on the command line, or setting the environment variable `QUARG_DEBUG` to a non-empty value.
 
 Decorators are provided to allow more fine-grained (but entirely
 optional) control:

--- a/quarg.py
+++ b/quarg.py
@@ -16,6 +16,7 @@ import functools
 import inspect
 import re
 import sys
+import traceback
 
 _arg_overrides = {}
 _output_fn = {}
@@ -151,7 +152,7 @@ def output(output_fn, *args, **kwargs):
     `output_fn` should be a function that processes the return value
     and returns a string. None can be passed as a special case to
     suppress output.
-    
+
     Additional positional parameters and keyword arguments may be passes along with the filter function. These are passes to the filter call using functools.partial.
     """
     def decorator(f):
@@ -183,6 +184,10 @@ def main(argv=sys.argv):
         parser = argparse.ArgumentParser(prog=argv[0],
                                          description=f.f_locals['__doc__'])
 
+        # Add Quarg control arguments
+        parser.add_argument("--quarg-debug", action="store_true",
+                            dest="_quarg_debug")
+
         if len(target_commands) == 1:
             # Only one command is exposed, so don't use a subcommand
             make_parser(target_commands[0], parser)
@@ -204,7 +209,10 @@ def main(argv=sys.argv):
                 if string_result:
                     print(string_result)
             except Exception as e:
-                print(str(e), file=sys.stderr)
+                if args._quarg_debug:
+                    traceback.print_exc(file=sys.stderr)
+                else:
+                    print(str(e), file=sys.stderr)
                 sys.exit(1)
         else:
             parser.print_usage(sys.stderr)

--- a/quarg.py
+++ b/quarg.py
@@ -75,11 +75,6 @@ def parse_docstring(doc):
     else:
         return ('', '', '')
 
-def envstring_to_bool(value):
-    """Convert an environment variable to a boolean"""
-    return (False if value is None
-            else (value.lower() not in ["0", "", "false", "no"]))
-
 # getargspec is deprecated in Python 3
 _getargspec = inspect.getfullargspec if hasattr(inspect, "getfullargspec") else inspect.getargspec
 
@@ -193,7 +188,7 @@ def main(argv=sys.argv):
         # Add Quarg control arguments
         parser.add_argument("--quarg-debug", action="store_true",
                             dest="_quarg_debug",
-                            default=envstring_to_bool(os.getenv("QUARG_DEBUG")))
+                            default=bool(os.getenv("QUARG_DEBUG")))
 
         if len(target_commands) == 1:
             # Only one command is exposed, so don't use a subcommand

--- a/quarg.py
+++ b/quarg.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 import argparse
 import functools
 import inspect
+import os
 import re
 import sys
 import traceback
@@ -73,6 +74,11 @@ def parse_docstring(doc):
                 {a:' '.join(l) for a,l in arghelp.items()})
     else:
         return ('', '', '')
+
+def envstring_to_bool(value):
+    """Convert an environment variable to a boolean"""
+    return (False if value is None
+            else (value.lower() not in ["0", "", "false", "no"]))
 
 # getargspec is deprecated in Python 3
 _getargspec = inspect.getfullargspec if hasattr(inspect, "getfullargspec") else inspect.getargspec
@@ -186,7 +192,8 @@ def main(argv=sys.argv):
 
         # Add Quarg control arguments
         parser.add_argument("--quarg-debug", action="store_true",
-                            dest="_quarg_debug")
+                            dest="_quarg_debug",
+                            default=envstring_to_bool(os.getenv("QUARG_DEBUG")))
 
         if len(target_commands) == 1:
             # Only one command is exposed, so don't use a subcommand

--- a/test_scripts/fail
+++ b/test_scripts/fail
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+import quarg
+
+def divide(x, y = 0):
+    return int(x) / y
+
+quarg.main()


### PR DESCRIPTION
This PR allows the user to override the pretty printing of top-level exceptions and reinstate the default (traceback) output. It introduces the notion of `--quarg...` arguments to control Quarg's behaviour, with `QUARG_...` environment variables as a fallback.